### PR TITLE
UGRIP First Estimator, Dataset YAML Files

### DIFF
--- a/examples/configs/estimators/ugrip_benchmark_estimators.yaml
+++ b/examples/configs/estimators/ugrip_benchmark_estimators.yaml
@@ -1,0 +1,58 @@
+# A. Information-Theoretic Methods
+- name: MaximumSequenceProbability
+- name: Perplexity
+- name: MeanTokenEntropy
+- name: TokenSAR
+
+# B. Consistency-Based Methods
+- name: NumSemSets
+- name: DegMat
+  cfg:
+    similarity_score: "NLI_score"
+    affinity: "entail"
+- name: DegMat
+  cfg:
+    similarity_score: "NLI_score"
+    affinity: "contra"
+- name: DegMat
+  cfg:
+    similarity_score: "Jaccard_score"
+- name: EigValLaplacian
+  cfg:
+    similarity_score: "NLI_score"
+    affinity: "entail"
+- name: EigValLaplacian
+  cfg:
+    similarity_score: "NLI_score"
+    affinity: "contra"
+- name: EigValLaplacian
+  cfg:
+    similarity_score: "Jaccard_score"
+- name: Eccentricity
+  cfg:
+    similarity_score: "NLI_score"
+    affinity: "entail"
+- name: Eccentricity
+  cfg:
+    similarity_score: "NLI_score"
+    affinity: "contra"
+- name: Eccentricity
+  cfg:
+    similarity_score: "Jaccard_score"
+- name: LexicalSimilarity
+  cfg:
+    metric: "rouge1"
+- name: LexicalSimilarity
+  cfg:
+    metric: "rouge2"
+- name: LexicalSimilarity
+  cfg:
+    metric: "rougeL"
+- name: LexicalSimilarity
+  cfg:
+    metric: "BLEU"
+
+# C. Hybrid Methods
+- name: SentenceSAR
+- name: SAR
+- name: SemanticEntropy

--- a/examples/configs/polygraph_eval_ugrip_gsm8k_direct.yaml
+++ b/examples/configs/polygraph_eval_ugrip_gsm8k_direct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: ugrip_benchmark_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['UGRIP-LM-Polygraph/gsm8k-direct', 'continuation']
+text_column: question
+label_column: answer
+train_split: train
+eval_split: test
+few_shot_prompt: null
+max_new_tokens: 20
+load_from_disk: false
+normalize: true
+trust_remote_code: false
+size: 10000
+generation_params:
+  generate_until:
+    - "\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_ugrip_gsm8k_reasoning.yaml
+++ b/examples/configs/polygraph_eval_ugrip_gsm8k_reasoning.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: ugrip_benchmark_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['UGRIP-LM-Polygraph/gsm8k-reasoning', 'continuation']
+text_column: question
+label_column: answer
+train_split: train
+eval_split: test
+few_shot_prompt: null
+max_new_tokens: 256
+load_from_disk: false
+normalize: true
+trust_remote_code: false
+size: 10000
+generation_params:
+  generate_until:
+    - "\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_ugrip_medmcqa_direct.yaml
+++ b/examples/configs/polygraph_eval_ugrip_medmcqa_direct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: ugrip_benchmark_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['UGRIP-LM-Polygraph/medmcqa-direct', 'continuation']
+text_column: question
+label_column: answer
+train_split: train
+eval_split: test
+few_shot_prompt: null
+max_new_tokens: 25
+load_from_disk: false
+normalize: true
+trust_remote_code: false
+size: 10000
+generation_params:
+  generate_until:
+    - "\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_ugrip_medmcqa_reasoning.yaml
+++ b/examples/configs/polygraph_eval_ugrip_medmcqa_reasoning.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: ugrip_benchmark_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['UGRIP-LM-Polygraph/medmcqa-reasoning', 'continuation']
+text_column: question
+label_column: answer
+train_split: train
+eval_split: test
+few_shot_prompt: null
+max_new_tokens: 256
+load_from_disk: false
+normalize: true
+trust_remote_code: false
+size: 10000
+generation_params:
+  generate_until:
+    - "\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_ugrip_mmlu_direct.yaml
+++ b/examples/configs/polygraph_eval_ugrip_mmlu_direct.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: ugrip_benchmark_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['UGRIP-LM-Polygraph/mmlu-direct', 'continuation']
+text_column: question
+label_column: answer
+train_split: train
+eval_split: test
+few_shot_prompt: null
+max_new_tokens: 1
+load_from_disk: false
+normalize: true
+trust_remote_code: false
+size: 10000
+generation_params:
+  generate_until:
+    - "\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1

--- a/examples/configs/polygraph_eval_ugrip_mmlu_reasoning.yaml
+++ b/examples/configs/polygraph_eval_ugrip_mmlu_reasoning.yaml
@@ -1,0 +1,40 @@
+hydra:
+  run:
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+defaults:
+  - model: bloomz-560m
+  - estimators: ugrip_benchmark_estimators
+  - stat_calculators: default_calculators
+  - _self_
+
+cache_path: ./workdir/output
+save_path: '${hydra:run.dir}'
+instruct: false
+task: qa
+
+dataset: ['UGRIP-LM-Polygraph/mmlu-reasoning', 'continuation']
+text_column: question
+label_column: answer
+train_split: train
+eval_split: test
+few_shot_prompt: null
+max_new_tokens: 100
+load_from_disk: false
+normalize: true
+trust_remote_code: false
+size: 10000
+generation_params:
+  generate_until:
+    - "\n"
+
+subsample_eval_dataset: -1
+
+generation_metrics: null
+
+ignore_exceptions: false
+
+batch_size: 1
+
+seed:
+    - 1


### PR DESCRIPTION
This pull request would add 7 new `.yaml` files to the ugrip branch.

```examples/configs/estimators/ugrip_benchmark_estimators.yaml```
 - Basic configuration for the benchmarking methods described in [ugrip/1_TASK_DESCRIPTION.md](https://github.com/stat-ml/ugrip/blob/main/1_TASK_DESCRIPTION.md)

```examples/configs/polygraph_eval_ugrip_gsm8k_direct.yaml
examples/configs/polygraph_eval_ugrip_gsm8k_reasoning.yaml
examples/configs/polygraph_eval_ugrip_medmcqa_direct.yaml
examples/configs/polygraph_eval_ugrip_medmcqa_reasoning.yaml
examples/configs/polygraph_eval_ugrip_mmlu_direct.yaml
examples/configs/polygraph_eval_ugrip_mmlu_reasoning.yaml
```
 - Preliminary configs for the 6 datasets we'll make. 

Note that as of the writing of this PR, we have not yet created the 6 HuggingFace datasets. However, we have our organization created and have standardized the naming conventions we will use for our datasets.
- Dataset name format: `UGRIP-LM-Polygraph/[originalname]-[direct,reasoning]`

These YAML files are not finalized. We will revisit them as we finalize what models we use and have our datasets uploaded to HuggingFace.