### PR TITLE
UGRIP Slurm batch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# Slurm logs (UGRIP)
+slurm_logs/
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/ugrip_run_benchmark.slurm
+++ b/ugrip_run_benchmark.slurm
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#SBATCH --job-name=ugrip_polygraph_benchmarks
+#SBATCH --output=slurm_logs/%x-%j.out 
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=2
+#SBATCH --cpus-per-task=16
+#SBATCH --gres=gpu:2
+#SBATCH --mem=96G
+#SBATCH --time=24:00:00
+
+# Create directory for slurm logs if it doesn't 
+# exist yet
+mkdir -p slurm_logs
+
+echo "Setting up conda environment..."
+module load miniconda3
+conda activate reasoning_uq
+
+echo "Beginning UGRIP Benchmark: 2 models, 2 GPUs"
+echo "Job started on $(hostname) at $(date)"
+
+# First benchmark: Llama 3.1 8b Instruct
+echo "Starting Llama-3.1 on GPU 0..."
+CUDA_VISIBLE_DEVICES=0 python ./scripts/polygraph_eval \
+    --config-name polygraph_eval_ugrip \
+    --multirun \
+    model=ugrip_llama_instruct \
+    dataset=ugrip_gsm8k_direct,ugrip_gsm8k_reasoning,ugrip_mmlu_direct,ugrip_mmlu_reasoning,ugrip_medmcqa_direct,ugrip_medmcqa_reasoning &
+
+# Second benchmark: Gemma 3 12b Instruct
+echo "Starting Gemma-2 on GPU 1..."
+CUDA_VISIBLE_DEVICES=1 python ./scripts/polygraph_eval \
+    --config-name polygraph_eval_ugrip \
+    --multirun \
+    model=ugrip_gemma_instruct \
+    dataset=ugrip_gsm8k_direct,ugrip_gsm8k_reasoning,ugrip_mmlu_direct,ugrip_mmlu_reasoning,ugrip_medmcqa_direct,ugrip_medmcqa_reasoning &
+
+echo "Waiting for all benchmark runs to complete..."
+wait 
+
+echo "All jobs finished at $(date)"


### PR DESCRIPTION
Added a slurm batch script which will run the benchmarking on 2 models and 6 datasets. It will request 2 GPUs and use one GPU per model. Assumes there's a miniconda3 environment called reasoning_uq. 

To run, just ensure you are in the `lm-polygraph` directory and then run the following command:
```bash
sbatch ugrip_run_benchmark.slurm
```

Check the status of the job with:
```bash
squeue -u $USER
```
When the job is complete, the terminal output will go to `slurm_logs/`. Results from the experiments will go to `workdir/output/`, organized in separate folders per model + dataset config. There are 12 total experiments. 