### PR TITLE
add Gemma3 compatibility

### DIFF
--- a/examples/configs/polygraph_eval_ugrip.yaml
+++ b/examples/configs/polygraph_eval_ugrip.yaml
@@ -1,13 +1,18 @@
 hydra:
   run:
-    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    dir: ${cache_path}/${task}/${model.path}/${dataset.0}/${now:%Y-%m-%d}/${now:%H-%M-%S}
 
 defaults:
   - model: ugrip_gemma_instruct
-  - dataset: ugrip_gsm8k_direct
   - estimators: ugrip_benchmark_estimators
   - stat_calculators: default_calculators
   - _self_
+
+task: qa
+dataset: ['UGRIP-LM-Polygraph/gsm8k-direct']
+text_column: question
+label_column: answer
+max_new_tokens: 20
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
@@ -24,7 +29,7 @@ generation_params:
   generate_until:
     - "\n"
 
-# subsample_eval_dataset: -1
+subsample_eval_dataset: 1
 
 # generation_metrics: null
 

--- a/examples/configs/polygraph_eval_ugrip.yaml
+++ b/examples/configs/polygraph_eval_ugrip.yaml
@@ -1,6 +1,6 @@
 hydra:
   run:
-    dir: ${cache_path}/${task}/${model.path}/${dataset.0}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
 
 defaults:
   - model: ugrip_gemma_instruct

--- a/src/lm_polygraph/stat_calculators/greedy_probs.py
+++ b/src/lm_polygraph/stat_calculators/greedy_probs.py
@@ -151,13 +151,19 @@ class GreedyProbsCalculator(StatCalculator):
             ll.append([log_probs[j, tokens[j]] for j in range(len(log_probs))])
 
         attention_all = []
+
+        config = model.model.config
+        if hasattr(config, 'text_config'):
+            config = config.text_config
+
         if self.output_attentions and (model.model_type != "vLLMCausalLM"):
             for i in range(len(texts)):
                 c = len(cut_sequences[i])
                 attn_mask = np.zeros(
+
                     shape=(
-                        model.model.config.num_attention_heads
-                        * model.model.config.num_hidden_layers,
+                        config.num_attention_heads
+                        * config.num_hidden_layers,
                         c,
                         c,
                     )

--- a/src/lm_polygraph/stat_calculators/sample.py
+++ b/src/lm_polygraph/stat_calculators/sample.py
@@ -230,6 +230,10 @@ class SamplingGenerationCalculator(StatCalculator):
             "sample_texts": texts,
         }
 
+        config = model.model.config
+        if hasattr(config, 'text_config'):
+            config = config.text_config
+
         if model.model_type != "vLLMCausalLM":
             out = OutputWrapper()
             batch_size = len(batch["input_ids"])
@@ -252,7 +256,7 @@ class SamplingGenerationCalculator(StatCalculator):
                     batch,
                     model.model_type,
                     level="token",
-                    hidden_layer=int(model.model.config.num_hidden_layers // 2),
+                    hidden_layer=int(config.num_hidden_layers // 2),
                 )
 
                 if cur_token_embeddings.dtype == torch.bfloat16:


### PR DESCRIPTION
Added Gemma3 compatibility by fixing the dynamo and config error.

Apparently, `torch.compile()` will break Gemma3 since it use special type of cache, based from the discussion [here](https://github.com/huggingface/transformers/issues/38333). So I followed their suggestion by disabling compile on text generation.
```py
# src/lm_polygraph/utils/model.py
class WhiteBoxModel(Model):
    ...
    def generate(self, **kwargs)
        ...
        generation = self.model.generate(**args, disable_compile="gemma" in self.model_path.lower())
        ...
    ...
```

Also, I put some conditional to use `Gemma3Config` and `Gemma3ForCausalLM` for only Gemma3 models on the model loading just to be extra safe.

Next, I fixed the config error, caused by Gemma3's difference in config layouting. For other models, we only need to access the model's config by doing `model.model.config.num_attention_heads` to get attention heads. But Gemma3 is different, we have to access `text_config` from `config`, like `model.model.config.text_config.num_attention_heads`. So I added a conditional to handle that in `src/lm_polygraph/stat_calculators/greedy_probs.py` and `src/lm_polygraph/stat_calculators/sample.py`.