### PR TITLE
Final(?) UGRIP YAML UGRIP setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,9 @@ cython_debug/
 # Slurm logs (UGRIP)
 slurm_logs/
 
+# Hydra multirun outputs (UGRIP)
+multirun/
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/examples/configs/dataset/ugrip_gsm8k_direct.yaml
+++ b/examples/configs/dataset/ugrip_gsm8k_direct.yaml
@@ -1,8 +1,1 @@
-defaults:
-  - _self_
-
-task: qa
-dataset: ['UGRIP-LM-Polygraph/gsm8k-direct', 'continuation']
-text_column: question
-label_column: answer
-max_new_tokens: 20
+['UGRIP-LM-Polygraph/gsm8k-direct', 'default']

--- a/examples/configs/dataset/ugrip_gsm8k_reasoning.yaml
+++ b/examples/configs/dataset/ugrip_gsm8k_reasoning.yaml
@@ -1,10 +1,1 @@
-defaults:
-  - _self_
-
-task: qa
-dataset: ['UGRIP-LM-Polygraph/gsm8k-reasoning', 'continuation']
-text_column: question
-label_column: answer
-max_new_tokens: 256
-# Do you need a space after? 
-output_ignore_regex: "(?s).### Answer: "
+['UGRIP-LM-Polygraph/gsm8k-reasoning', 'continuation']

--- a/examples/configs/dataset/ugrip_medmcqa_direct.yaml
+++ b/examples/configs/dataset/ugrip_medmcqa_direct.yaml
@@ -1,9 +1,1 @@
-defaults:
-  - _self_
-
-instruct: false
-task: qa
-dataset: ['UGRIP-LM-Polygraph/medmcqa-direct', 'continuation']
-text_column: question
-label_column: answer
-max_new_tokens: 25
+['UGRIP-LM-Polygraph/medmcqa-direct', 'default']

--- a/examples/configs/dataset/ugrip_medmcqa_reasoning.yaml
+++ b/examples/configs/dataset/ugrip_medmcqa_reasoning.yaml
@@ -1,10 +1,1 @@
-defaults:
-  - _self_
-
-task: qa
-dataset: ['UGRIP-LM-Polygraph/medmcqa-reasoning', 'continuation']
-text_column: question
-label_column: answer
-max_new_tokens: 256
-# Do you need a space after? 
-output_ignore_regex: "(?s).### Answer: "
+['UGRIP-LM-Polygraph/medmcqa-reasoning', 'default']

--- a/examples/configs/dataset/ugrip_mmlu_direct.yaml
+++ b/examples/configs/dataset/ugrip_mmlu_direct.yaml
@@ -1,8 +1,1 @@
-defaults:
-  - _self_
-
-task: qa
-dataset: ['UGRIP-LM-Polygraph/mmlu-direct', 'continuation']
-text_column: question
-label_column: answer
-max_new_tokens: 1
+['UGRIP-LM-Polygraph/mmlu-direct', 'default']

--- a/examples/configs/dataset/ugrip_mmlu_reasoning.yaml
+++ b/examples/configs/dataset/ugrip_mmlu_reasoning.yaml
@@ -1,10 +1,1 @@
-defaults:
-  - _self_
-
-task: qa
-dataset: ['UGRIP-LM-Polygraph/mmlu-reasoning', 'continuation']
-text_column: question
-label_column: answer
-max_new_tokens: 100
-# Do you need a space after? 
-output_ignore_regex: "(?s).### Answer: "
+['UGRIP-LM-Polygraph/mmlu-reasoning', 'default']

--- a/examples/configs/polygraph_eval_ugrip.yaml
+++ b/examples/configs/polygraph_eval_ugrip.yaml
@@ -4,27 +4,20 @@ hydra:
 
 defaults:
   - model: ugrip_llama_instruct
-  # - dataset: ugrip_gsm8k_direct
-  # - ugrip_gsm8k_direct
+  - dataset: ugrip_gsm8k_direct
   - estimators: ugrip_benchmark_estimators
   - stat_calculators: default_calculators
   - _self_
 
 task: qa
-dataset: ['UGRIP-LM-Polygraph/gsm8k-direct']
 text_column: question
 label_column: answer
-max_new_tokens: 20
+# Use max_new_tokens= to override
+max_new_tokens: 500
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
 
-task: qa
-# dataset: ['UGRIP-LM-Polygraph/gsm8k-direct', 'default']
-dataset: ['UGRIP-LM-Polygraph/mmlu-direct', 'default']
-text_column: question
-label_column: answer
-max_new_tokens: 20
 
 train_split: train
 eval_split: test
@@ -32,16 +25,19 @@ eval_split: test
 load_from_disk: false
 normalize: true
 trust_remote_code: false
-# Limit to 10,000 samples? Is this bad?
 size: 10000
-subsample_eval_dataset: 25
 generation_params:
   generate_until:
     - "\n"
 
-subsample_eval_dataset: 1
+# \/ How many samples per dataset
+# Change with +subsample_eval_dataset=25
+# subsample_eval_dataset: 25
 
-# generation_metrics: null
+# \/ What to ignore in model output
+# output_ignore_regex: "(?s).### Answer: "
+# Below is important for Gemma outputs
+output_ignore_regex: r"\s*<end_of_turn>"
 
 ignore_exceptions: false
 

--- a/examples/configs/polygraph_eval_ugrip.yaml
+++ b/examples/configs/polygraph_eval_ugrip.yaml
@@ -3,14 +3,22 @@ hydra:
     dir: ${cache_path}/${task}/${model}/${dataset}/${now:%Y-%m-%d}/${now:%H-%M-%S}
 
 defaults:
-  - model: ugrip_gemma_instruct
-  - dataset: ugrip_gsm8k_direct
+  - model: ugrip_llama_instruct
+  # - dataset: ugrip_gsm8k_direct
+  # - ugrip_gsm8k_direct
   - estimators: ugrip_benchmark_estimators
   - stat_calculators: default_calculators
   - _self_
 
 cache_path: ./workdir/output
 save_path: '${hydra:run.dir}'
+
+task: qa
+# dataset: ['UGRIP-LM-Polygraph/gsm8k-direct', 'default']
+dataset: ['UGRIP-LM-Polygraph/mmlu-direct', 'default']
+text_column: question
+label_column: answer
+max_new_tokens: 20
 
 train_split: train
 eval_split: test
@@ -20,6 +28,7 @@ normalize: true
 trust_remote_code: false
 # Limit to 10,000 samples? Is this bad?
 size: 10000
+subsample_eval_dataset: 25
 generation_params:
   generate_until:
     - "\n"


### PR DESCRIPTION
Includes hotfixes from Abel's branch that allowed Gemma to run. 

The dataset YAML files were changed to just contain one line, e.g.: `['UGRIP-LM-Polygraph/gsm8k-reasoning', 'default']`. This is because previously, I tried to put more information into each dataset YAML file (e.g. `task: qa', `max_new_tokens: 50`, etc.). However, this did not work, as the end result was a YAML config that looked like...
```
dataset:
  dataset: ['UGRIP-LM-Polygraph/gsm8k-reasoning', 'default']
  task: qa
  max_new_tokens: 50
```
...which obviously does not work. I moved other settings such as `task`, `text_column`, `max_new_tokens` to the main yaml file. 

On the command line, can override `max_new_tokens` with `max_new_tokens=<new_val>`, and can change how many samples are looked at per dataset with `+subsample_eval_dataset=<val>`. 